### PR TITLE
Removed Output of Delimiters On Null Prop Value

### DIFF
--- a/src/combyne.js
+++ b/src/combyne.js
@@ -491,10 +491,6 @@ var render = function() {
         if (typeof obj !== "object") {
           output += obj;
         }
-        // Keep brackets
-        else {
-          output += delimiters.START_PROP + obj.prop + delimiters.END_PROP;
-        }
 
         mode.unset("prop");
 


### PR DESCRIPTION
The output delimiters were originally placed back into the output stream to allow for applying more data to the output. This can now be accomplished with partials.
