### PR TITLE
Fix 2 of the template examples in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ var output = tmpl.render(context);
 ###Using filters on variables###
 
 ``` javascript
-var template = '{{test|reverse}}';
+var template = '{{lol|reverse}}';
 var context = { lol: 'test' };
 
 var tmpl = combyne(template);
@@ -114,7 +114,7 @@ var output = tmpl.render(context);
 ####Chaining filters on variables####
 
 ``` javascript
-var template = '{{test|reverse|toUpper}}';
+var template = '{{lol|reverse|toUpper}}';
 var context = { lol: 'test' };
 
 var tmpl = combyne(template);


### PR DESCRIPTION
I was reading through the documentation and noticed that 2 of the examples seemed wrong.  As it was written, it didn't make sense to pass a context to the first 2 filter examples.

Merge this down if my revision is what you intended.
