### PR TITLE
Loosens limitations on naming partials/filters.

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -153,38 +153,38 @@ define(function(require, exports, module) {
     // No node in a partial expression?
     delete root.nodes;
 
-    // Partials have arguments passed.
-    root.args = [];
+    // All stringified contents found.
+    var input = "";
 
     LOOP:
     while (this.stack.length) {
       var node = this.stack.shift();
 
       switch (node.name) {
-        case "OTHER": {
-          if (root.value === undefined) {
-            root.value = node.capture[0].trim();
-          }
-          else {
-            root.args.push(node.capture[0].trim());
-          }
-
-          break;
-        }
-
-        case "WHITESPACE": {
-          break;
-        }
-
         case "END_EXPR": {
           break LOOP;
         }
 
         default: {
-          throw new Error("Unexpected " + node.name + " encountered.");
+          // Accumulate all values into the input variable, will split later.
+          input += node.capture[0];
         }
       }
     }
+
+    // Split up the input into space-delimited parts.
+    var parts = input.trim().split(" ");
+
+    // The partial name.
+    root.value = parts[0];
+
+    // If no value, this is an error.
+    if (!root.value) {
+      throw new Error("Missing valid partials name.");
+    }
+
+    // Partials have arguments passed.
+    root.args = parts.slice(1);
 
     return root;
   };
@@ -204,30 +204,17 @@ define(function(require, exports, module) {
 
     var previous = {};
 
+    // All stringified contents found.
+    var input = "";
+
     LOOP:
     while (this.stack.length) {
       var node = this.stack.shift();
 
       switch (node.name) {
-        case "OTHER": {
-          if (current.value === undefined) {
-            current.value = node.capture[0].trim();
-          }
-          else {
-            current.args.push(node.capture[0].trim());
-          }
-
-          break;
-        }
-
-        case "WHITESPACE": {
-          break;
-        }
-
         case "END_RAW":
         case "END_PROP": {
           root.filters.push(current);
-
           break LOOP;
         }
 
@@ -238,13 +225,28 @@ define(function(require, exports, module) {
           break;
         }
 
+        // Accumulate all values into the input variable, will split later.
         default: {
-          throw new Error("Unexpected " + node.name + " encountered.");
+          input += node.capture[0];
         }
       }
 
       previous = node;
     }
+
+    // Split up the input into space-delimited parts.
+    var parts = input.trim().split(" ");
+
+    // The partial name.
+    current.value = parts[0];
+
+    // If no value, this is an error.
+    if (!current.value) {
+      throw new Error("Missing valid filter name.");
+    }
+
+    // Partials have arguments passed.
+    current.args = parts.slice(1);
 
     return root;
   };

--- a/test/tests/filters.js
+++ b/test/tests/filters.js
@@ -11,9 +11,9 @@ define(function(require, exports, module) {
       assert.equal(output, "|| |    |");
     });
 
-    it("will error if invalid tokens are present", function() {
+    it("will error if invalid filter name is provided", function() {
       assert.throws(function() {
-        var tmpl = combyne("{{test|< 5}");
+        var tmpl = combyne("{{test|");
         tmpl.registerFilter("filter", function() {});
         var output = tmpl.render();
       });
@@ -154,6 +154,18 @@ define(function(require, exports, module) {
       var output = tmpl.render({ item: [ "hi", "you", "own" ] });
 
       assert.equal(output, " Name: hi  Name: you  Name: own ");
+    });
+
+    it("can render with reserved grammar", function() {
+      var tmpl = combyne("{{test|as}}");
+
+      tmpl.registerFilter("as", function(value) {
+        return value + " as";
+      });
+
+      var output = tmpl.render({ test: "hello world" });
+
+      assert.equal(output, "hello world as");
     });
   });
 });

--- a/test/tests/partials.js
+++ b/test/tests/partials.js
@@ -4,6 +4,13 @@ define(function(require, exports, module) {
   var combyne = require("../../lib/index");
 
   describe("Partials", function() {
+    it("will error if invalid partial name is provided", function() {
+      assert.throws(function() {
+        var tmpl = combyne("{%partial%}");
+        var output = tmpl.render();
+      });
+    });
+
     it("can inject without clobbering the parent", function() {
       var tmpl = combyne("{{test}} {%partial test%}");
 
@@ -54,6 +61,16 @@ define(function(require, exports, module) {
         var tmpl = combyne("{%partial 5 > 4%}");
         var output = tmpl.render();
       });
+    });
+
+    it("can render with reserved grammar", function() {
+      var tmpl = combyne("{{test}} {%partial partials/test%} 123");
+
+      tmpl.registerPartial("partials/test", combyne("prop", {}));
+
+      var output = tmpl.render({ test: "hello world" });
+
+      assert.equal(output, "hello world prop 123");
     });
   });
 });


### PR DESCRIPTION
At the moment reserved tokens will not be added to partial or filter
names meaning you could not do the following:

``` javascript
var tmpl = combyne("{%partial partials/test%}");
tmpl.registerPartial("partials/test", combyne("Hello world"));
```

An error would pop up saying unexpected token PARTIAL.  In my opinion, I
designed this too strictly and it should be changed to allow for any
variety of characters.
