### PR TITLE
Ensure conditionals do not break on reserved words

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -243,7 +243,7 @@ define(function(require, exports, module) {
           return condition.value;
         }
       }
-    }).join(" ");
+    }).join("");
 
     // If an else was provided, hook into it.
     var els = node.els ? this.process(node.els.nodes) : null;

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -434,7 +434,7 @@ define(function(require, exports, module) {
     root.type = root.type || "ConditionalExpression";
     root.conditions = root.conditions || [];
 
-    var previous = {};
+    var prev = {};
 
     if (kind === "ELSE") {
       root.els = { nodes: [] };
@@ -506,8 +506,8 @@ define(function(require, exports, module) {
 
             break;
           }
-          else if (previous.type === "Identifier") {
-            previous.value += value;
+          else if (prev.type === "Identifier" || prev.type === "Literal") {
+            prev.value += value;
 
             break;
           }
@@ -523,7 +523,7 @@ define(function(require, exports, module) {
       }
 
       // Store the previous condition object if it exists.
-      previous = root.conditions[root.conditions.length - 1] || {};
+      prev = root.conditions[root.conditions.length - 1] || {};
     }
 
     this.make(root, "END_IF");

--- a/test/tests/expressions.js
+++ b/test/tests/expressions.js
@@ -166,6 +166,13 @@ define(function(require, exports, module) {
 
         assert.equal(output, "hello");
       });
+
+      it("can evaluate strings containing reserved words", function() {
+        var tmpl = combyne("{%if hello == 'helloif'%}hello{%endif%}");
+        var output = tmpl.render({ hello: "helloif" });
+
+        assert.equal(output, "hello");
+      });
     });
 
     describe("else statement", function() {


### PR DESCRIPTION
Strange how reserved words come in as literals, but this clears up the issue where the keyword if could not be used inside of a string for an if statement.
