### PR TITLE
Fixes a major issue with nested filter lookup

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -172,6 +172,11 @@ define(function(require, exports, module) {
         }
 
         default: {
+          // Ensure a node always has a value.
+          if (node.value == null) {
+            break;
+          }
+
           // Special work necessary to handle new lines within loops.
           var indexOf = node.value.indexOf("\n");
           var escaped = escapeValue(node.value);

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -303,7 +303,7 @@ define(function(require, exports, module) {
         case "FILTER": {
           root.filters.push(current);
           this.constructFilter(root);
-          break;
+          break LOOP;
         }
 
         // Accumulate all values into the input variable, will split later.

--- a/test/tests/filters.js
+++ b/test/tests/filters.js
@@ -179,5 +179,21 @@ define(function(require, exports, module) {
 
       assert.equal(output, "hello");
     });
+
+    it("can chain filters within a conditional", function() {
+      var tmpl = combyne("{%if false%}test{%else%}{{test|addWord 'try'|reverse}}{%endif%}");
+
+      tmpl.registerFilter("addWord", function(val, word) {
+        return val + word;
+      });
+
+      tmpl.registerFilter("reverse", function(val) {
+        return val.split("").reverse().join("");
+      });
+
+      var output = tmpl.render({ test: "prop" });
+
+      assert.equal(output, "yrtporp");
+    });
   });
 });


### PR DESCRIPTION
When a nested filter was present, it would not properly terminate the
outer loop which resulted in over parsing and breaking complex
templates.
