### PR TITLE
Ensure partials nest partials and filters

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -363,6 +363,8 @@ define(function(require, exports, module) {
   Compiler.prototype.compilePartial = function(node) {
     return [
       "(",
+        "(partials['" + node.value + "']._partials = partials),",
+        "(partials['" + node.value + "']._filters = filters),",
         "partials['" + node.value + "'].render(",
           node.args.length ? normalizeIdentifier(node.args[0]) : node.data,
         ")",

--- a/test/tests/partials.js
+++ b/test/tests/partials.js
@@ -85,6 +85,17 @@ define(function(require, exports, module) {
       assert.equal(output, "hello world prop 123");
     });
 
+    it("can nest partials", function() {
+      var tmpl = combyne("{%partial test%}");
+
+      tmpl.registerPartial("test", combyne("{%partial nested%}", {}));
+      tmpl.registerPartial("nested", combyne("nested", {}));
+
+      var output = tmpl.render();
+
+      assert.equal(output, "nested");
+    });
+
     describe("template inheritance", function() {
       it("can inject a parent template", function() {
         var tmpl = combyne("{%extend layout as content%}{{test}}{%endextend%}");


### PR DESCRIPTION
This fixes an issue where nested partials cannot reference the top level registered partials.
