### PR TITLE
Ensure that undefined is never printed

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -242,7 +242,7 @@ define(function(require, exports, module) {
           "?", encode ? "encode(" + identifier + "(" + node.args + "))" :
             identifier + "(" + node.args + ")",
           ":", encode ? "encode(" + identifier + ") == null ? '' : encode(" +
-            identifier + ")" : identifier,
+            identifier + ")" : identifier + " == null ? '' : " + identifier,
       ")"
     ].join(" ");
 

--- a/test/tests/properties.js
+++ b/test/tests/properties.js
@@ -22,6 +22,26 @@ define(function(require, exports, module) {
       });
     });
 
+    it("can process raw nested properties", function() {
+      var output = combyne("{{{nested.property}}}").render({
+        nested: {
+          property: "test"
+        }
+      });
+
+      assert.equal(output, "test");
+    });
+
+    it("does not print undefined properties", function() {
+      var output = combyne("{{{nested.property}}}").render({
+        nested: {
+          property: undefined
+        }
+      });
+
+      assert.equal(output, "");
+    });
+
     it("can replace many values", function() {
       var output = combyne("{{test}} {{test1}}").render({
         test: "hello world",


### PR DESCRIPTION
There is a bug where undefined would be printed literally.  The compiler has been updated to account for this.
