### PR TITLE
Use regexs instead of hacky spaces

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -8,7 +8,8 @@ define(function(require, exports, module) {
   "use strict";
 
   // Utils.
-  var escapeDelimiter = require("./utils/escape_delimiter");
+  var escapeDelimiter = require("./utils/escape_delimiter"),
+      breakString;
 
   // Support.
   require("./support/array/map");
@@ -25,26 +26,110 @@ define(function(require, exports, module) {
     this.delimiters = delimiters;
 
     this.internal = [
-      makeEntry("START_IF", "if"),
-      makeEntry("ELSE", "else"),
-      makeEntry("ELSIF", "elsif"),
-      makeEntry("END_IF", "endif"),
-      makeEntry("NOT", "not"),
-      makeEntry("EQUALITY", "=="),
-      makeEntry("NOT_EQUALITY", "!="),
-      makeEntry("GREATER_THAN_EQUAL", ">="),
-      makeEntry("GREATER_THAN", ">"),
-      makeEntry("LESS_THAN_EQUAL", "<="),
-      makeEntry("LESS_THAN", "<"),
-      makeEntry("NOT", "not"),
-      makeEntry("START_EACH", "each"),
-      makeEntry("END_EACH", "endeach"),
-      makeEntry("ASSIGN", "as"),
-      makeEntry("PARTIAL", "partial"),
-      makeEntry("START_EXTEND", "extend"),
-      makeEntry("END_EXTEND", "endextend"),
-      makeEntry("MAGIC", ".")
-    ];
+        {
+          name: "START_IF",
+          value: "if",
+          cantStartWord: false
+        },
+        {
+          name: "ELSE",
+          value: "else",
+          cantStartWord: false
+        },
+        {
+          name: "ELSIF",
+          value: "elsif",
+          cantStartWord: false
+        },
+        {
+          name: "END_IF",
+          value: "endif",
+          cantStartWord: false
+        },
+        {
+          name: "NOT",
+          value: "not",
+          cantStartWord: false
+        },
+        {
+          name: "EQUALITY",
+          value: "==",
+          cantStartWord: true
+        },
+        {
+          name: "NOT_EQUALITY",
+          value: "!=",
+          cantStartWord: true
+        },
+        {
+          name: "GREATER_THAN_EQUAL",
+          value: ">=",
+          cantStartWord: true
+        },
+        {
+          name: "GREATER_THAN",
+          value: ">",
+          cantStartWord: true
+        },
+        {
+          name: "LESS_THAN_EQUAL",
+          value: "<=",
+          cantStartWord: true
+        },
+        {
+          name: "LESS_THAN",
+          value: "<",
+          cantStartWord: true
+        },
+        {
+          name: "START_EACH",
+          value: "each",
+          cantStartWord: false
+        },
+        {
+          name: "END_EACH",
+          value: "endeach",
+          cantStartWord: false
+        },
+        {
+          name: "ASSIGN",
+          value: "as",
+          cantStartWord: false
+        },
+        {
+          name: "PARTIAL",
+          value: "partial",
+          cantStartWord: false
+        },
+        {
+          name: "START_EXTEND",
+          value: "extend",
+          cantStartWord: false
+        },
+        {
+          name: "END_EXTEND",
+          value: "endextend",
+          cantStartWord: false
+        },
+        {
+          name: "MAGIC",
+          value: ".",
+          cantStartWord: true
+        }
+    ]
+
+    breakString = "\\s|" + Object.keys(this.delimiters).map(function(key) {
+      return escapeDelimiter(this.delimiters[key]);
+    }, this)
+    .join("|").concat(this.internal.map(function(internal) {
+      return escapeDelimiter(internal.value);
+    }, this).join("|"));
+
+    this.internal = this.internal.map(function(internal) {
+      return makeEntry(internal.name, internal.value, internal.cantStartWord);
+    }, this).reduce(function(a, b) {
+      return a.concat(b);
+    });
   }
 
   /**
@@ -55,14 +140,25 @@ define(function(require, exports, module) {
    * @param {string} value - To be escaped and used within a RegExp.
    * @returns {object} The normalized metadata.
    */
-  function makeEntry(name, value) {
+  function makeEntry(name, value, cantStartWord) {
     var escaped = escapeDelimiter(value);
+    var out = [];
+    if (cantStartWord) {
 
-    return {
-      name: name,
-      escaped: escaped,
-      test: new RegExp("^" + escaped)
-    };
+      out.push("(^" + escaped + ")");
+    }
+    else {
+      out.push("(^" + escaped + "$)");
+      out.push("(^" + escaped + ")(" + breakString + ")");
+    }
+
+    return out.map(function(toOutput) {
+      return {
+        name: name,
+        escaped: toOutput.replace("^", "").replace("^", ""),
+        test: new RegExp(toOutput)// + escaped + "$")
+      };
+    }, this);
   }
 
   /**
@@ -86,8 +182,10 @@ define(function(require, exports, module) {
 
     // Add all normalized delimiters into the grammar.
     grammar = grammar.map(function(key) {
-      return makeEntry(key, this.delimiters[key]);
-    }, this);
+      return makeEntry(key, this.delimiters[key], true);
+    }, this).reduce(function(a, b) {
+      return a.concat(b);
+    });
 
     // Add all normalized internals into the grammar.
     grammar.push.apply(grammar, this.internal);
@@ -98,20 +196,21 @@ define(function(require, exports, module) {
     }).join("|");
 
     // Add whitespace to grammar.
-    grammar.push({
+    grammar.splice(0, 0, {
       name: "WHITESPACE",
-      test: /^[\ \t\r\n]+/
+      test: /^(\s+)/
     });
 
     // Add whitespace to the whitelist.
-    string += "| |\t|\r|\n";
+    string += "|\\s";
 
     // The everything-else bucket.
     grammar.push({
       name: "OTHER",
-      test: new RegExp("^((?!" + string + ").)*")
+      test: new RegExp("^(((?!" + string + ").)*)")
     });
 
+    this.breakString = breakString;
     return grammar;
   };
 

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -36,11 +36,11 @@ define(function(require, exports, module) {
   function parseNextToken(template, grammar, stack) {
     grammar.some(function(token) {
       var capture = token.test.exec(template);
-
       // Ignore empty captures.
-      if (capture && capture[0]) {
-        template = template.replace(token.test, "");
-        stack.push({ name: token.name, capture: capture });
+      if (capture && capture.length > 1 && capture[1]) {
+        var replace = capture[1].trim() || capture[1];
+        template = template.replace(replace, "");
+        stack.push({ name: token.name, capture: [replace] });
         return true;
       }
     });


### PR DESCRIPTION
The regexs here get pretty complex, but time doesnt seem to be affected much. Allows each internal delimiter to specify if it can be part of a word, ie {{{ ALWAYS gets treated as a delimiter, but 'if' wont get caught if there are more letters following it (requires another forced delimiter, a whitespace, or end of string)
