### PR TITLE
Removed brackets around switch cases

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -143,44 +143,36 @@ define(function(require, exports, module) {
     // Parse the Tree and execute the respective compile to JavaScript method.
     nodes.map(function(node, index) {
       switch (node.type) {
-        case "RawProperty": {
+        case "RawProperty":
           commands.push(this.compileProperty(node, false));
           break;
-        }
 
-        case "Property": {
+        case "Property":
           commands.push(this.compileProperty(node, true));
           break;
-        }
 
-        case "ConditionalExpression": {
+        case "ConditionalExpression":
           commands.push(this.compileConditional(node));
           break;
-        }
 
-        case "LoopExpression": {
+        case "LoopExpression":
           commands.push(this.compileLoop(node));
           break;
-        }
 
-        case "PartialExpression": {
+        case "PartialExpression":
           commands.push(this.compilePartial(node));
           break;
-        }
 
-        case "ExtendExpression": {
+        case "ExtendExpression":
           commands.push(this.compileExtend(node));
           break;
-        }
 
-        default: {
+        default:
           // Ensure a node always has a value.
-          if (node.value == null) {
-            break;
+          if (node.value) {
+            commands.push("'" + escapeValue(node.value) + "'");
           }
-
-          commands.push("'" + escapeValue(node.value) + "'");
-        }
+          break;
       }
     }, this);
 
@@ -249,23 +241,19 @@ define(function(require, exports, module) {
 
     var condition = node.conditions.map(function(condition) {
       switch (condition.type) {
-        case "Identifier": {
+        case "Identifier":
           return _this.compileProperty(
             condition.value,
             condition.value.type == "Property");
-        }
 
-        case "Not": {
+        case "Not":
           return "!";
-        }
 
-        case "Literal": {
+        case "Literal":
           return condition.value;
-        }
 
-        case "Equality": {
+        case "Equality":
           return condition.value;
-        }
       }
     }).join("");
 

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -48,17 +48,15 @@ define(function(require, exports, module) {
       node = this.stack.shift();
 
       switch (node.name) {
-        case "START_RAW": {
+        case "START_RAW":
           root.nodes.push(this.constructProperty(false));
           break;
-        }
 
-        case "START_PROP": {
+        case "START_PROP":
           root.nodes.push(this.constructProperty(true));
           break;
-        }
 
-        case "START_EXPR": {
+        case "START_EXPR":
           if (result = this.constructExpression(root, END)) {
             root.nodes.push(result);
             break;
@@ -70,13 +68,11 @@ define(function(require, exports, module) {
           }
 
           break;
-        }
 
-        case "END_EXPR": {
+        case "END_EXPR":
           break;
-        }
 
-        case "WHITESPACE": {
+        case "WHITESPACE":
           var capture = node.capture[0];
 
           // Trim newlines from expression ends.
@@ -90,9 +86,8 @@ define(function(require, exports, module) {
           });
 
           break;
-        }
 
-        default: {
+        default:
           var prevWhitespace = "";
 
           // Detect previous whitespace to condense.
@@ -107,7 +102,6 @@ define(function(require, exports, module) {
           });
 
           break;
-        }
       }
 
       prev = node;
@@ -155,10 +149,9 @@ define(function(require, exports, module) {
       }
 
       switch (node.name) {
-        case "FILTER": {
+        case "FILTER":
           propertyDescriptor.value = input.trim();
           return this.constructFilter(propertyDescriptor);
-        }
 
         case "END_EXPR":
         case "EQUALITY":
@@ -167,7 +160,7 @@ define(function(require, exports, module) {
         case "GREATER_THAN_EQUAL":
         case "LESS_THAN":
         case "LESS_THAN_EQUAL":
-        case "ASSIGN": {
+        case "ASSIGN":
           processParsedProperty();
 
           // This property is embedded in some of expression, so lets stop
@@ -176,19 +169,17 @@ define(function(require, exports, module) {
           this.stack.unshift(node);
 
           return propertyDescriptor;
-        }
 
         case "END_RAW":
         case "END_PROP":
-        case "END_EXPR": {
+        case "END_EXPR":
           processParsedProperty();
 
           return propertyDescriptor;
-        }
 
-        default: {
+        default:
           input += node.capture[0];
-        }
+          break;
       }
 
       previous = node;
@@ -221,19 +212,17 @@ define(function(require, exports, module) {
       var node = this.stack.shift();
 
       switch (node.name) {
-        case "END_EXPR": {
+        case "END_EXPR":
           break LOOP;
-        }
 
-        case "ASSIGN": {
+        case "ASSIGN":
           side = "partial";
           break;
-        }
 
-        default: {
+        default:
           // Capture the template and partial values.
           value[side] += node.capture[0];
-        }
+          break;
       }
     }
 
@@ -283,20 +272,17 @@ define(function(require, exports, module) {
       var node = this.stack.shift();
 
       switch (node.name) {
-        case "END_EXPR": {
+        case "END_EXPR":
           break LOOP;
-        }
 
-        case "MAGIC": {
+        case "MAGIC":
           // If requested, pass the parent's data to the partial.
           root.data = "data";
           break;
-        }
 
-        default: {
+        default:
           // Accumulate all values into the input variable, will split later.
           input += node.capture[0];
-        }
       }
     }
 
@@ -353,7 +339,7 @@ define(function(require, exports, module) {
         case "GREATER_THAN_EQUAL":
         case "LESS_THAN":
         case "LESS_THAN_EQUAL":
-        case "ASSIGN": {
+        case "ASSIGN":
           root.filters.push(current);
 
           // This filter is embedded in some of expression, so lets stop
@@ -362,25 +348,21 @@ define(function(require, exports, module) {
           this.stack.unshift(node);
 
           break LOOP;
-        }
 
         case "END_RAW":
-        case "END_PROP": {
+        case "END_PROP":
           root.filters.push(current);
           break LOOP;
-        }
 
         // Allow nested filters.
-        case "FILTER": {
+        case "FILTER":
           root.filters.push(current);
           this.constructFilter(root);
           break LOOP;
-        }
 
         // Accumulate all values into the input variable, will split later.
-        default: {
+        default:
           input += node.capture[0];
-        }
       }
 
       previous = node;
@@ -422,7 +404,7 @@ define(function(require, exports, module) {
       var node = this.stack.shift();
 
       switch (node.name) {
-        case "ASSIGN": {
+        case "ASSIGN":
           isLeftSide = false;
 
           root.conditions.push({
@@ -431,17 +413,14 @@ define(function(require, exports, module) {
           });
 
           break;
-        }
 
-        case "END_EXPR": {
+        case "END_EXPR":
           break LOOP;
-        }
 
-        case "WHITESPACE": {
+        case "WHITESPACE":
           break;
-        }
 
-        default: {
+        default:
           // If we're on the left hand side and there are already conditions,
           // this is the only time we're aren't pushing a value descriptor.
           if (!isLeftSide) {
@@ -464,7 +443,6 @@ define(function(require, exports, module) {
           }
 
           break;
-        }
       }
     }
 
@@ -487,22 +465,19 @@ define(function(require, exports, module) {
       var node = this.stack.shift();
 
       switch (node.name) {
-        case "COMMENT": {
+        case "COMMENT":
           if (previous.name === "START_EXPR") {
             this.constructComment(root);
-            break;
           }
 
           break;
-        }
 
-        case "END_EXPR": {
+        case "END_EXPR":
           if (previous.name === "COMMENT") {
             return false;
           }
 
           break;
-        }
       }
 
       previous = node;
@@ -542,33 +517,30 @@ define(function(require, exports, module) {
       var value = node.capture[0].trim();
 
       switch (node.name) {
-        case "NOT": {
+        case "NOT":
           root.conditions.push({
             type: "Not"
           });
 
           break;
-        }
 
         case "EQUALITY":
         case "NOT_EQUALITY":
         case "GREATER_THAN":
         case "GREATER_THAN_EQUAL":
         case "LESS_THAN":
-        case "LESS_THAN_EQUAL": {
+        case "LESS_THAN_EQUAL":
           root.conditions.push({
             type: "Equality",
             value: node.capture[0].trim()
           });
 
           break;
-        }
 
-        case "END_EXPR": {
+        case "END_EXPR":
           break LOOP;
-        }
 
-        default: {
+        default:
           // If it's a whitespace we need the non-trimmed value
           if (node.name == "WHITESPACE") {
             value = node.capture[0];
@@ -579,8 +551,6 @@ define(function(require, exports, module) {
               type: "Literal",
               value: value
             });
-
-            break;
           }
           // Easy way to determine if the value is NaN or not.
           else if (Number(value) === Number(value)) {
@@ -594,13 +564,9 @@ define(function(require, exports, module) {
               type: "Literal",
               value: value
             });
-
-            break;
           }
           else if (prev.type === "Literal") {
             prev.value += value;
-
-            break;
           }
           else {
 
@@ -614,10 +580,9 @@ define(function(require, exports, module) {
               type: "Identifier",
               value: this.constructProperty(node.name != "START_RAW")
             });
-
-            break;
           }
-        }
+
+          break;
       }
 
       // Store the previous condition object if it exists.
@@ -650,43 +615,35 @@ define(function(require, exports, module) {
 
       switch (type.name) {
         //  WHEN ANY OF THESE ARE HIT, BREAK OUT.
-        case END: {
+        case END:
           return;
-        }
 
-        case "WHITESPACE": {
+        case "WHITESPACE":
           break;
-        }
 
-        case "COMMENT": {
+        case "COMMENT":
           return this.constructComment(expressionRoot);
-        }
 
-        case "START_EACH": {
+        case "START_EACH":
           return this.constructEach(expressionRoot);
-        }
 
         case "ELSIF":
         case "ELSE":
-        case "START_IF": {
+        case "START_IF":
           if (type.name !== "START_IF") {
             expressionRoot = root;
           }
 
           return this.constructConditional(expressionRoot, type.name);
-        }
 
-        case "PARTIAL": {
+        case "PARTIAL":
           return this.constructPartial(expressionRoot);
-        }
 
-        case "START_EXTEND": {
+        case "START_EXTEND":
           return this.constructExtend(expressionRoot);
-        }
 
-        default: {
+        default:
           throw new Error("Invalid expression type: " + type.name);
-        }
       }
     }
   };


### PR DESCRIPTION
The code complexity tool was not registering `break` inside of a bracketed
code block and was thinking that every switch case was falling through
to the next. This gave an inflated code complexity score so I just
decided to remove the brackets.
