### PR TITLE
Added a failing test for loops with filters and parameters

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -220,9 +220,14 @@ define(function(require, exports, module) {
       var args = filter.args.length ? ", " + filter.args.map(function(arg) {
         var value = arg.value;
 
+        // If not a string, normalize.
         if (value.indexOf("'") === -1 && value.indexOf("\"") === -1) {
-          if (!Number(value)) {
-            return normalizeIdentifier(value);
+          // Not a number.
+          if (Number(value) !== Number(value)) {
+            // Not a boolean.
+            if (value !== "true" && value !== "false") {
+              return normalizeIdentifier(value);
+            }
           }
         }
 

--- a/test/tests/expressions.js
+++ b/test/tests/expressions.js
@@ -442,6 +442,33 @@ define(function(require, exports, module) {
         assert.equal(output, "HOLAHALLOHELLOBONJOURAHOJ");
       });
 
+      it("can loop over a property called through a filter with a parameter", function() {
+        var tmpl = combyne("{%each hello|case true %}{{.}}{%endeach%}{%each hello|case false %}{{.}}{%endeach%}");
+
+        tmpl.registerFilter("case", function(array, toUpperCase) {
+          return array.map(function (entry) {
+            if (toUpperCase) {
+              return entry.toUpperCase();
+            }
+            else {
+              return entry.toLowerCase();
+            }
+          });
+        });
+
+        var output = tmpl.render({
+          hello: [
+            "Hola",
+            "Hallo",
+            "Hello",
+            "bonjour",
+            "ahoj"
+          ]
+        });
+
+        assert.equal(output, "HOLAHALLOHELLOBONJOURAHOJholahallohellobonjourahoj");
+      });
+
       it("can loop over the root called through a filter", function() {
         var tmpl = combyne("{%each |upper%}{{.}}{%endeach%}");
 

--- a/test/tests/expressions.js
+++ b/test/tests/expressions.js
@@ -446,13 +446,8 @@ define(function(require, exports, module) {
         var tmpl = combyne("{%each hello|case true %}{{.}}{%endeach%}{%each hello|case false %}{{.}}{%endeach%}");
 
         tmpl.registerFilter("case", function(array, toUpperCase) {
-          return array.map(function (entry) {
-            if (toUpperCase) {
-              return entry.toUpperCase();
-            }
-            else {
-              return entry.toLowerCase();
-            }
+          return array.map(function(entry) {
+            return toUpperCase ? entry.toUpperCase() : entry.toLowerCase();
           });
         });
 


### PR DESCRIPTION
Currently if you have a filter in a loop that has a parameter, the parameter never gets passed into the filter.