### PR TITLE
Support large files

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -89,7 +89,10 @@ define(function(require, exports, module) {
     this.tree = tree;
     this.string = "";
 
-    var compiledSource = this.process(this.tree.nodes);
+    // Optimization pass will flatten large templates to result in faster
+    // rendering.
+    var nodes = this.optimize(this.tree.nodes);
+    var compiledSource = this.process(nodes);
 
     // The compiled function body.
     var body = [];
@@ -133,6 +136,32 @@ define(function(require, exports, module) {
       "}"
     ].join("\n");
   }
+
+  /**
+   * Takes a pass over the full token set to optimize and eliminate potential
+   * bugs associated with super large templates.
+   *
+   * @memberOf module:compiler.Compiler
+   * @param {array} nodes
+   * @return {array} optimized nodes
+   */
+  Compiler.prototype.optimize = function(nodes) {
+    return nodes.reduce(function(memo, node) {
+      var previous = memo[memo.length - 1];
+
+      // Optimize text nodes together.
+      if (previous && previous.type === "Text" && node.type === "Text") {
+        previous.value += node.value;
+      }
+
+      // This is the first item
+      else {
+        memo.push(node);
+      }
+
+      return memo;
+    }, []);
+  };
 
   /**
    * A recursively called method to detect how to compile each Node in the

--- a/test/tests/lib/compiler.js
+++ b/test/tests/lib/compiler.js
@@ -5,7 +5,7 @@ define(function(require, exports, module) {
 
   describe("Compiler", function() {
     it("is a constructor", function() {
-      assert.ok(typeof Compiler === "function"); 
+      assert.ok(typeof Compiler === "function");
     });
   });
 });

--- a/test/tests/tokenParsing.js
+++ b/test/tests/tokenParsing.js
@@ -51,7 +51,13 @@ define(function(require, exports, module) {
       // large file. *Cough IE 7*.
       this.timeout(50000);
 
-      var largeFile = new Array(10000).join('<test>');
+      var largeFile = "";
+
+      // Build up a large file to simulate.  Using a for loop instead of an
+      // array since IE 8 was erroring with out-of-memory errors.
+      for (var i = 0; i < 10000; i++) {
+        largeFile += "<test>";
+      }
 
       var template = combyne(largeFile);
       var output = template.render();

--- a/test/tests/tokenParsing.js
+++ b/test/tests/tokenParsing.js
@@ -47,6 +47,10 @@ define(function(require, exports, module) {
     });
 
     it("will not error on large files", function() {
+      // Timeout increase for older browsers that may be slow at rendering a
+      // large file. *Cough IE 7*.
+      this.timeout(50000);
+
       var largeFile = new Array(10000).join('<test>');
 
       var template = combyne(largeFile);

--- a/test/tests/tokenParsing.js
+++ b/test/tests/tokenParsing.js
@@ -45,24 +45,5 @@ define(function(require, exports, module) {
 
       assert.equal(output, "'hello world'");
     });
-
-    it("will not error on large files", function() {
-      // Timeout increase for older browsers that may be slow at rendering a
-      // large file. *Cough IE 7*.
-      this.timeout(50000);
-
-      var largeFile = "";
-
-      // Build up a large file to simulate.  Using a for loop instead of an
-      // array since IE 8 was erroring with out-of-memory errors.
-      for (var i = 0; i < 1000; i++) {
-        largeFile += "<test>";
-      }
-
-      var template = combyne(largeFile);
-      var output = template.render();
-
-      assert.equal(output, largeFile);
-    });
   });
 });

--- a/test/tests/tokenParsing.js
+++ b/test/tests/tokenParsing.js
@@ -55,7 +55,7 @@ define(function(require, exports, module) {
 
       // Build up a large file to simulate.  Using a for loop instead of an
       // array since IE 8 was erroring with out-of-memory errors.
-      for (var i = 0; i < 10000; i++) {
+      for (var i = 0; i < 1000; i++) {
         largeFile += "<test>";
       }
 

--- a/test/tests/tokenParsing.js
+++ b/test/tests/tokenParsing.js
@@ -45,5 +45,14 @@ define(function(require, exports, module) {
 
       assert.equal(output, "'hello world'");
     });
+
+    it("will not error on large files", function() {
+      var largeFile = new Array(10000).join('<test>');
+
+      var template = combyne(largeFile);
+      var output = template.render();
+
+      assert.equal(output, largeFile);
+    });
   });
 });


### PR DESCRIPTION
I noticed that on super large templates I wasn't optimizing strings, so it would be making a giant concatenation.  Instead, I now optimize the nodes to be concatenated before rendering.