### PR TITLE
Add missing package.json fields and upgrade dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,24 +3,33 @@
   "description": "A template engine that works the way you expect.",
   "version": "0.8.1",
   "author": "Tim Branyen (@tbranyen)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tbranyen/combyne.git"
+  },
   "main": "dist/combyne.js",
   "devDependencies": {
-    "dateformat": "^1.0.11",
     "amdefine": "^1.0.0",
     "browserify": "^11.0.1",
+    "dateformat": "^1.0.11",
     "deamdify": "^0.1.1",
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.0",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-jscs-checker": "^0.4.4",
     "grunt-karma": "^0.12.0",
     "grunt-karma-coveralls": "^2.5.4",
     "grunt-simple-mocha": "^0.4.0",
     "jsdoc": "^3.3.2",
+    "karma": "^0.13.9",
     "karma-coverage": "^0.5.0",
     "karma-mocha": "^0.2.0",
     "karma-phantomjs-launcher": "^0.2.1",
-    "karma-sauce-launcher": "^0.2.14"
+    "karma-sauce-launcher": "^0.2.14",
+    "mocha": "^2.2.5",
+    "phantomjs": "^1.9.18"
   },
   "scripts": {
     "test": "grunt test",


### PR DESCRIPTION
NPM Install complained about no license or repository fields, so I added those in.

Many dev dependencies were producing errors about unsatisfied peer dependencies in the upcoming NPM 3 world, so those were also added (phantomjs, mocha and karma, notably).