### PR TITLE
Remove the need for global bower installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: node_js
 sudo: false
 node_js:
 - 0.12
-before_script:
-- npm install -g grunt-cli bower
-- bower install
 branches:
   only:
   - master

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "dist/combyne.js",
   "devDependencies": {
     "amdefine": "^1.0.0",
+    "bower": "^1.5.2",
     "browserify": "^11.0.1",
     "browserify-derequire": "^0.9.4",
     "dateformat": "^1.0.11",
@@ -32,6 +33,7 @@
     "phantomjs": "^1.9.18"
   },
   "scripts": {
+    "postinstall": "bower install",
     "test": "grunt test",
     "ci": "grunt test coveralls",
     "doc": "jsdoc -r -d docs/ lib/ README.md"


### PR DESCRIPTION
grunt-cli is already part of devDependencies: this adds bower to the list as well, so that a 'postinstall' script can auto-install the bower deps. If you prefer not to do it this way that's fine, I just see it as a developer convenience.

TBD based on conversation (and a decision/patch I'll leave to you, @tbranyen): remove dependency on bower entirely