### PR TITLE
Remove Saucelabs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,6 @@ node_js:
 before_script:
 - npm install -g grunt-cli bower
 - bower install
-script:
-- if ${SAUCE_LABS:=false}; then grunt karma:saucelabs; else npm run ci; fi;
 branches:
   only:
   - master
-matrix:
-  include:
-  - node_js: 0.12
-    env: SAUCE_LABS=true
-env:
-  global:
-  - secure: R3bM/HAisAEz4LpC35o3/FJhH8HctOluCTxB/pZXmuKPDlCpIMYVZGo+CKeWP4avOvTMdnuXaKimdNKNMflK+IwF8SLC3+Wv4sQELGJ6cbYcL4hue9pYD0rDjJCdOC72cgqA1paNcUe91VfWCjRK/OCYQ7RrRQ9BPwHX0bvxlWk=
-  - secure: IGpplkIzAMV0Uvg4wmK1RqyztHWsU49KSgA+FlcsibgBhYozay06OQAhcsbrUOGgGNw/4A3TNn2nuOaZJNGhrAEGwekodi2QOSUFlPY6K0f916iV8lz5rlhSP6CmgBZpyCEIfVCebiQ3rAiOSi2HBZ3tonat2VEwun8ddzA08LA=

--- a/build/tasks/karma.coffee
+++ b/build/tasks/karma.coffee
@@ -1,33 +1,7 @@
-require "karma-sauce-launcher"
 require "karma-coverage"
 
 module.exports = ->
   @loadNpmTasks "grunt-karma"
-
-  sauceLabs =
-    sl_safari:
-      base: "SauceLabs"
-      browserName: "safari"
-
-    sl_chrome:
-      base: "SauceLabs"
-      browserName: "chrome"
-
-    sl_firefox:
-      base: "SauceLabs"
-      browserName: "firefox"
-
-    sl_ie_8:
-      base: "SauceLabs"
-      platform: "Windows XP"
-      browserName: "internet explorer"
-      version: "8"
-
-    sl_ie_9:
-      base: "SauceLabs"
-      platform: "Windows 7"
-      browserName: "internet explorer"
-      version: "9"
 
   @config "karma",
     options:
@@ -108,22 +82,3 @@ module.exports = ->
           { pattern: "bower_components/**/*.*", included: false }
           { pattern: "test/tests/**/*.js", included: false }
         ]
-
-    saucelabs:
-      options:
-        captureTimeout: 120000
-        singleRun: true
-        customLaunchers: sauceLabs
-        browsers: Object.keys sauceLabs
-        reporters: ["dots", "saucelabs"]
-
-        plugins: [
-          "karma-mocha"
-          "karma-phantomjs-launcher"
-          "karma-sauce-launcher"
-          "karma-coverage"
-        ]
-
-        sauceLabs:
-          testName: "Combyne Browser Tests"
-          takeScreenshots: false

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "karma-coverage": "^0.5.0",
     "karma-mocha": "^0.2.0",
     "karma-phantomjs-launcher": "^0.2.1",
-    "karma-sauce-launcher": "^0.2.14",
     "mocha": "^2.2.5",
     "phantomjs": "^1.9.18"
   },


### PR DESCRIPTION
While its nice to test real browsers continuously, this service
absolutely sucks.

It does not:

- Have stable and consistent runners which means false failures
- Allow contributors to run tests in their PRs causing false failures
- The interface on the site is terrible and the new beta is even worse

/rant