### PR TITLE
Ensure that conditional arguments are parsed valid

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -404,12 +404,39 @@ define(function(require, exports, module) {
     // Find the left side identifier.
     var isLeftSide = true;
 
+    // Iteration arguments are whitespace separated.
+    var splitArg = false;
+
+    // The key name has been detected.
+    var hasKey = false;
+
+    var handleConditionArgument = function(prev) {
+      if (!splitArg && prev && prev.type === "Identifier") {
+        prev.value += node.capture[0];
+      }
+      else {
+        root.conditions.push({
+          type: "Identifier",
+          value: node.capture[0]
+        });
+
+        hasKey = true;
+      }
+    };
+
     LOOP:
     while (this.stack.length) {
       var node = this.stack.shift();
+      var conditions = root.conditions;
+      var prev = conditions.length && conditions[conditions.length - 1];
 
       switch (node.name) {
         case "ASSIGN":
+          if (!isLeftSide) {
+            handleConditionArgument(prev);
+            continue;
+          }
+
           isLeftSide = false;
 
           root.conditions.push({
@@ -423,16 +450,17 @@ define(function(require, exports, module) {
           break LOOP;
 
         case "WHITESPACE":
+          if (!isLeftSide && hasKey) {
+            splitArg = true;
+          }
+
           break;
 
         default:
           // If we're on the left hand side and there are already conditions,
           // this is the only time we're aren't pushing a value descriptor.
           if (!isLeftSide) {
-            root.conditions.push({
-              type: "Identifier",
-              value: node.capture[0].trim()
-            });
+            handleConditionArgument(prev);
           }
           else {
             // This value needs to be processed by constructProperty so put it

--- a/test/tests/expressions.js
+++ b/test/tests/expressions.js
@@ -619,6 +619,18 @@ define(function(require, exports, module) {
         assert.equal(output, "lol:hi you:me? what:test ");
       });
 
+      it("can use database as a value name", function() {
+        var tmpl = combyne("{%each databases as database name%}{{name}}:{{database}}{%endeach%}");
+
+        var output = tmpl.render({
+          databases: {
+            database1: "online"
+          }
+        });
+
+        assert.equal(output, "database1:online");
+      });
+
       it("will ignore properties on the prototype", function() {
         var tmpl = combyne("{%each demo as v k%}{{k}}:{{v}} {%endeach%}");
 


### PR DESCRIPTION
While working on a sample benchmarking app, I noticed that the following
was invalid:

```
{%each databases as database name%}{{database}}: {{name}}{%endeach%}
```

Using the the object:

```
{
  "database1": "online"
}
```

I was unable to get the template to render correctly.

After inspecting the `template.tree` object, I was able to discover that
the tokenizer had correctly found two cases of ASSIGNMENT the `as` in
database.

I updated the AST generation code to account for actual assignment and
properly adjust depending on what's passed.