### PR TITLE
Updated compiler to spit out warnings instead of crashing

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -131,7 +131,13 @@ define(function(require, exports, module) {
         "registerPartial: " + registerPartial + ",",
         "registerFilter: " + registerFilter + ",",
         "render: function(data) {",
-          "return " + this.func + "(data, this)",
+          "try {",
+            "return " + this.func + "(data, this);",
+          "} catch (ex) {",
+            type, encode,
+            "console.error(ex);",
+            "return '<pre>' + encode(ex + ex.stack) + '</pre>';",
+          "}",
         "}",
       "}"
     ].join("\n");


### PR DESCRIPTION
This will spit out both `console.error` and output the stack and error wrapped in a `<pre>`. Figured that would make it less jarring in HTML, and nbd if rendered anywhere else.